### PR TITLE
Add vertical bar support for left/right screen edges

### DIFF
--- a/a-bar/AppDelegate.swift
+++ b/a-bar/AppDelegate.swift
@@ -193,6 +193,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         barWindows[key] = barWindow
         barWindow.makeKeyAndOrderFront(nil)
       }
+
+      // Create left bar if configured
+      if displayConfig.leftBar != nil {
+        let key = BarWindowKey(displayIndex: displayIndex, position: .left)
+        let barWindow = BarWindow(
+          screen: screen,
+          displayIndex: displayIndex,
+          position: .left
+        )
+        barWindows[key] = barWindow
+        barWindow.makeKeyAndOrderFront(nil)
+      }
+
+      // Create right bar if configured
+      if displayConfig.rightBar != nil {
+        let key = BarWindowKey(displayIndex: displayIndex, position: .right)
+        let barWindow = BarWindow(
+          screen: screen,
+          displayIndex: displayIndex,
+          position: .right
+        )
+        barWindows[key] = barWindow
+        barWindow.makeKeyAndOrderFront(nil)
+      }
     }
   }
   

--- a/a-bar/BarView.swift
+++ b/a-bar/BarView.swift
@@ -102,6 +102,7 @@ struct BarView: View {
           WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
         }
       }
+      .frame(maxWidth: .infinity)
       .frame(maxHeight: .infinity, alignment: .top)
 
       // Middle section (mapped from center)
@@ -110,6 +111,7 @@ struct BarView: View {
           WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
         }
       }
+      .frame(maxWidth: .infinity)
 
       // Bottom section (mapped from right)
       VStack(spacing: globalSettings.barElementGap) {
@@ -117,9 +119,11 @@ struct BarView: View {
           WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
         }
       }
+      .frame(maxWidth: .infinity)
       .frame(maxHeight: .infinity, alignment: .bottom)
     }
     .padding(.vertical, 8)
+    .padding(.horizontal, 4)
   }
 
   // MARK: - Border Overlays
@@ -254,7 +258,7 @@ struct WidgetContainer: View {
 
 // MARK: - Widget Orientation Environment Key
 
-private struct WidgetOrientationKey: EnvironmentKey {
+struct WidgetOrientationKey: EnvironmentKey {
   static let defaultValue: WidgetOrientation = .horizontal
 }
 
@@ -262,5 +266,44 @@ extension EnvironmentValues {
   var widgetOrientation: WidgetOrientation {
     get { self[WidgetOrientationKey.self] }
     set { self[WidgetOrientationKey.self] = newValue }
+  }
+}
+
+// MARK: - Adaptive Stack for Orientation-Aware Layout
+
+/// A stack that switches between HStack and VStack based on widget orientation
+struct AdaptiveStack<Content: View>: View {
+  @Environment(\.widgetOrientation) var orientation
+
+  let horizontalSpacing: CGFloat
+  let verticalSpacing: CGFloat
+  let horizontalAlignment: VerticalAlignment
+  let verticalAlignment: HorizontalAlignment
+  @ViewBuilder let content: () -> Content
+
+  init(
+    hSpacing: CGFloat = 4,
+    vSpacing: CGFloat = 2,
+    hAlignment: VerticalAlignment = .center,
+    vAlignment: HorizontalAlignment = .center,
+    @ViewBuilder content: @escaping () -> Content
+  ) {
+    self.horizontalSpacing = hSpacing
+    self.verticalSpacing = vSpacing
+    self.horizontalAlignment = hAlignment
+    self.verticalAlignment = vAlignment
+    self.content = content
+  }
+
+  var body: some View {
+    if orientation == .vertical {
+      VStack(alignment: verticalAlignment, spacing: verticalSpacing) {
+        content()
+      }
+    } else {
+      HStack(alignment: horizontalAlignment, spacing: horizontalSpacing) {
+        content()
+      }
+    }
   }
 }

--- a/a-bar/BarView.swift
+++ b/a-bar/BarView.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+/// Orientation for widget layout
+enum WidgetOrientation {
+  case horizontal
+  case vertical
+}
+
 /// Main bar view containing all widgets arranged in sections
 struct BarView: View {
   let displayIndex: Int
@@ -25,61 +31,140 @@ struct BarView: View {
     layoutManager.barLayout(forDisplay: displayIndex, position: position)
   }
 
+  /// Whether this bar is vertical (left or right edge)
+  private var isVertical: Bool {
+    position.isVertical
+  }
+
+  /// Widget orientation based on bar position
+  private var orientation: WidgetOrientation {
+    isVertical ? .vertical : .horizontal
+  }
+
   // The body of the view constructs the layout of the bar using an HStack to arrange the left, center, and right sections. Each section contains its respective widgets, which are rendered using the WidgetContainer view. The bar's background and optional border are also applied here based on user settings.
   var body: some View {
     GeometryReader { geometry in
       let borderEnabled = globalSettings.showBorder
-      HStack(spacing: 0) {
-        // Left section
-        HStack(spacing: globalSettings.barElementGap) {
-          ForEach(leftWidgets) { widget in
-            WidgetContainer(widget: widget, displayIndex: displayIndex)
-          }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
 
-        // Center section
-        HStack(spacing: globalSettings.barElementGap) {
-          ForEach(centerWidgets) { widget in
-            WidgetContainer(widget: widget, displayIndex: displayIndex)
-          }
-        }
-
-        // Right section
-        HStack(spacing: globalSettings.barElementGap) {
-          ForEach(rightWidgets) { widget in
-            WidgetContainer(widget: widget, displayIndex: displayIndex)
-          }
-        }
-        .frame(maxWidth: .infinity, alignment: .trailing)
+      if isVertical {
+        verticalBarContent
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .background(barBackground)
+          .overlay(verticalBorderOverlay(enabled: borderEnabled))
+      } else {
+        horizontalBarContent
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .background(barBackground)
+          .overlay(horizontalBorderOverlay(enabled: borderEnabled))
       }
-      // A minimal padding is necessary on the built-in screen as it has rounded corners
-      // Without it, the content might be clipped or appear too close to the edges
-      .padding(.horizontal, 8)
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .background(barBackground)
-      .overlay(
-        Group {
-          if borderEnabled {
-            // Border at top for bottom bar, at bottom for top bar
-            if position == .top {
-              VStack(spacing: 0) {
-                Spacer(minLength: 0)
-                Rectangle()
-                  .fill(theme.minor)
-                  .frame(height: 1)
-              }
-            } else {
-              VStack(spacing: 0) {
-                Rectangle()
-                  .fill(theme.minor)
-                  .frame(height: 1)
-                Spacer(minLength: 0)
-              }
-            }
-          }
-        }, alignment: position == .top ? .bottom : .top
-      )
+    }
+  }
+
+  // MARK: - Horizontal Bar Layout (Top/Bottom)
+
+  @ViewBuilder
+  private var horizontalBarContent: some View {
+    HStack(spacing: 0) {
+      // Left section
+      HStack(spacing: globalSettings.barElementGap) {
+        ForEach(leftWidgets) { widget in
+          WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+
+      // Center section
+      HStack(spacing: globalSettings.barElementGap) {
+        ForEach(centerWidgets) { widget in
+          WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
+        }
+      }
+
+      // Right section
+      HStack(spacing: globalSettings.barElementGap) {
+        ForEach(rightWidgets) { widget in
+          WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+    .padding(.horizontal, 8)
+  }
+
+  // MARK: - Vertical Bar Layout (Left/Right)
+
+  @ViewBuilder
+  private var verticalBarContent: some View {
+    VStack(spacing: 0) {
+      // Top section (mapped from left)
+      VStack(spacing: globalSettings.barElementGap) {
+        ForEach(leftWidgets) { widget in
+          WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
+        }
+      }
+      .frame(maxHeight: .infinity, alignment: .top)
+
+      // Middle section (mapped from center)
+      VStack(spacing: globalSettings.barElementGap) {
+        ForEach(centerWidgets) { widget in
+          WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
+        }
+      }
+
+      // Bottom section (mapped from right)
+      VStack(spacing: globalSettings.barElementGap) {
+        ForEach(rightWidgets) { widget in
+          WidgetContainer(widget: widget, displayIndex: displayIndex, orientation: orientation)
+        }
+      }
+      .frame(maxHeight: .infinity, alignment: .bottom)
+    }
+    .padding(.vertical, 8)
+  }
+
+  // MARK: - Border Overlays
+
+  @ViewBuilder
+  private func horizontalBorderOverlay(enabled: Bool) -> some View {
+    if enabled {
+      // Border at bottom for top bar, at top for bottom bar
+      if position == .top {
+        VStack(spacing: 0) {
+          Spacer(minLength: 0)
+          Rectangle()
+            .fill(theme.minor)
+            .frame(height: 1)
+        }
+      } else {
+        VStack(spacing: 0) {
+          Rectangle()
+            .fill(theme.minor)
+            .frame(height: 1)
+          Spacer(minLength: 0)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func verticalBorderOverlay(enabled: Bool) -> some View {
+    if enabled {
+      // Border on right edge for left bar, on left edge for right bar
+      if position == .left {
+        HStack(spacing: 0) {
+          Spacer(minLength: 0)
+          Rectangle()
+            .fill(theme.minor)
+            .frame(width: 1)
+        }
+      } else {
+        HStack(spacing: 0) {
+          Rectangle()
+            .fill(theme.minor)
+            .frame(width: 1)
+          Spacer(minLength: 0)
+        }
+      }
     }
   }
 
@@ -108,6 +193,7 @@ struct BarView: View {
 struct WidgetContainer: View {
   let widget: WidgetInstance
   let displayIndex: Int
+  var orientation: WidgetOrientation = .horizontal
 
   @EnvironmentObject var settings: SettingsManager
   @EnvironmentObject var yabaiService: YabaiService
@@ -162,5 +248,19 @@ struct WidgetContainer: View {
         }
       }
     }
+    .environment(\.widgetOrientation, orientation)
+  }
+}
+
+// MARK: - Widget Orientation Environment Key
+
+private struct WidgetOrientationKey: EnvironmentKey {
+  static let defaultValue: WidgetOrientation = .horizontal
+}
+
+extension EnvironmentValues {
+  var widgetOrientation: WidgetOrientation {
+    get { self[WidgetOrientationKey.self] }
+    set { self[WidgetOrientationKey.self] = newValue }
   }
 }

--- a/a-bar/BarWindow.swift
+++ b/a-bar/BarWindow.swift
@@ -10,7 +10,7 @@ class BarWindow: NSPanel {
   // The hosting view that contains the SwiftUI content of the bar
   private var hostingView: NSHostingView<AnyView>?
 
-  // Initialize the bar window with the appropriate screen, display index, and position (top or bottom)
+  // Initialize the bar window with the appropriate screen, display index, and position (top, bottom, left, or right)
   init(screen: NSScreen, displayIndex: Int, position: BarPosition) {
     self.barScreen = screen
     self.displayIndex = displayIndex
@@ -19,30 +19,46 @@ class BarWindow: NSPanel {
     // Calculate frame for the bar
     let settings = SettingsManager.shared.settings.global
     let barHeight = settings.barHeight
+    let barWidth = settings.barWidth
     // Padding is hardcoded for now, but can be made user-configurable if needed. It provides spacing from the screen edges.
     let padding: CGFloat = 0
 
     let screenFrame = screen.frame
 
-    let barY: CGFloat
+    let barFrame: NSRect
     switch position {
     case .top:
       // Position the bar at the top of the screen, accounting for the menu bar height and padding
-      barY = screenFrame.maxY - barHeight - padding
+      barFrame = NSRect(
+        x: screenFrame.minX + padding,
+        y: screenFrame.maxY - barHeight - padding,
+        width: screenFrame.width - (padding * 2),
+        height: barHeight
+      )
     case .bottom:
       // Position the bar at the bottom of the screen, accounting for padding
-      barY = screenFrame.minY + padding
+      barFrame = NSRect(
+        x: screenFrame.minX + padding,
+        y: screenFrame.minY + padding,
+        width: screenFrame.width - (padding * 2),
+        height: barHeight
+      )
+    case .left:
+      barFrame = NSRect(
+        x: screenFrame.minX + padding,
+        y: screenFrame.minY + padding,
+        width: barWidth,
+        height: screenFrame.height - (padding * 2)
+      )
+    case .right:
+      barFrame = NSRect(
+        x: screenFrame.maxX - barWidth - padding,
+        y: screenFrame.minY + padding,
+        width: barWidth,
+        height: screenFrame.height - (padding * 2)
+      )
     }
 
-    // The bar spans the full width of the screen, minus any horizontal padding
-    let barFrame = NSRect(
-      x: screenFrame.minX + padding,
-      y: barY,
-      width: screenFrame.width - (padding * 2),
-      height: barHeight
-    )
-    
-    //
     super.init(
       contentRect: barFrame,
       styleMask: [.borderless, .nonactivatingPanel, .hudWindow],

--- a/a-bar/Models/Settings.swift
+++ b/a-bar/Models/Settings.swift
@@ -244,6 +244,11 @@ class SettingsManager: ObservableObject {
       validated.global.barHeight = 34
     }
 
+    if validated.global.barWidth < 40 || validated.global.barWidth > 300 {
+      print("⚠️ Invalid barWidth (\(validated.global.barWidth)), using default")
+      validated.global.barWidth = 120
+    }
+
     if validated.global.fontSize < 6 || validated.global.fontSize > 72 {
       print("⚠️ Invalid fontSize (\(validated.global.fontSize)), using default")
       validated.global.fontSize = 11
@@ -392,6 +397,7 @@ struct GlobalSettings: Codable, Equatable {
   var barEnabled: Bool = true
   var launchAtLogin: Bool = false
   var barHeight: CGFloat = 34
+  var barWidth: CGFloat = 120  // Width for vertical bars (left/right)
   var fontSize: CGFloat = 11
   var fontName: String = ""
   var barPadding: CGFloat = 4

--- a/a-bar/Models/WidgetTypes.swift
+++ b/a-bar/Models/WidgetTypes.swift
@@ -149,11 +149,33 @@ enum WidgetSection: String, Codable, CaseIterable {
 enum BarPosition: String, Codable, CaseIterable {
   case top
   case bottom
+  case left
+  case right
 
   var displayName: String {
     switch self {
     case .top: return "Top"
     case .bottom: return "Bottom"
+    case .left: return "Left"
+    case .right: return "Right"
+    }
+  }
+
+  /// Whether this is a vertical bar (left or right edge)
+  var isVertical: Bool {
+    self == .left || self == .right
+  }
+
+  /// Display name for sections in vertical bars (left→top, center→middle, right→bottom)
+  func sectionDisplayName(for section: WidgetSection) -> String {
+    if isVertical {
+      switch section {
+      case .left: return "Top"
+      case .center: return "Middle"
+      case .right: return "Bottom"
+      }
+    } else {
+      return section.displayName
     }
   }
 }
@@ -244,24 +266,30 @@ struct DisplayConfiguration: Codable, Identifiable, Equatable {
   var name: String  // User-friendly name (e.g., "Built-in Display", "External Monitor")
   var topBar: SingleBarLayout?
   var bottomBar: SingleBarLayout?
+  var leftBar: SingleBarLayout?
+  var rightBar: SingleBarLayout?
 
   init(
     id: UUID = UUID(),
     displayIndex: Int,
     name: String = "Display",
     topBar: SingleBarLayout? = nil,
-    bottomBar: SingleBarLayout? = nil
+    bottomBar: SingleBarLayout? = nil,
+    leftBar: SingleBarLayout? = nil,
+    rightBar: SingleBarLayout? = nil
   ) {
     self.id = id
     self.displayIndex = displayIndex
     self.name = name
     self.topBar = topBar
     self.bottomBar = bottomBar
+    self.leftBar = leftBar
+    self.rightBar = rightBar
   }
 
   /// Check if display has any bars configured
   var hasBars: Bool {
-    topBar != nil || bottomBar != nil
+    topBar != nil || bottomBar != nil || leftBar != nil || rightBar != nil
   }
 }
 
@@ -284,6 +312,8 @@ struct MultiDisplayLayout: Codable, Equatable {
     switch position {
     case .top: return config.topBar
     case .bottom: return config.bottomBar
+    case .left: return config.leftBar
+    case .right: return config.rightBar
     }
   }
 

--- a/a-bar/Views/Settings/AppearanceSettingsView.swift
+++ b/a-bar/Views/Settings/AppearanceSettingsView.swift
@@ -24,6 +24,17 @@ struct AppearanceSettingsView: View {
             }
 
             HStack {
+              Text("Bar width (vertical)")
+              Spacer()
+              Slider(value: binding(\.global.barWidth), in: 40...300, step: 1)
+                .frame(width: 150)
+              TextField("", value: binding(\.global.barWidth), formatter: NumberFormatter())
+                .frame(width: 60)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+              Text("px")
+            }
+
+            HStack {
               Text("Bar padding")
               Spacer()
               TextField("", value: binding(\.global.barPadding), formatter: NumberFormatter())

--- a/a-bar/Widgets/BaseWidgetView.swift
+++ b/a-bar/Widgets/BaseWidgetView.swift
@@ -12,6 +12,7 @@ struct BaseWidgetView<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     @EnvironmentObject var settings: SettingsManager
+    @Environment(\.widgetOrientation) var orientation
 
     @State private var isHovered = false
 
@@ -44,6 +45,10 @@ struct BaseWidgetView<Content: View>: View {
         settings.settings.global
     }
 
+    private var isVertical: Bool {
+        orientation == .vertical
+    }
+
     var body: some View {
         content()
             .font(
@@ -53,11 +58,14 @@ struct BaseWidgetView<Content: View>: View {
             )
             .lineLimit(1)
             .truncationMode(.tail)
-            .fixedSize(horizontal: true, vertical: false)
-            .padding(.horizontal, noPadding ? 0 : 6)
+            .multilineTextAlignment(isVertical ? .center : .leading)
+            .fixedSize(horizontal: !isVertical, vertical: false)
+            .padding(.horizontal, noPadding ? 0 : (isVertical ? 4 : 6))
             .padding(.vertical, noPadding ? 0 : 4)
-            .frame(maxHeight: .infinity)
-            .frame(width: width)
+            .frame(maxHeight: isVertical ? nil : .infinity)
+            .frame(maxWidth: isVertical ? .infinity : nil)
+            .frame(width: isVertical ? nil : width)
+            .clipped()
             .background(backgroundView)
             .contentShape(Rectangle())
             .onTapGesture {
@@ -80,7 +88,8 @@ struct BaseWidgetView<Content: View>: View {
                     }
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, isVertical ? 2 : 4)
+            .padding(.horizontal, isVertical ? 2 : 0)
     }
 
     @ViewBuilder

--- a/a-bar/Widgets/Custom/UserWidget.swift
+++ b/a-bar/Widgets/Custom/UserWidget.swift
@@ -64,7 +64,7 @@ struct UserWidget: View {
         backgroundColor: customBackgroundColor,
         onClick: config.clickCommand != nil ? executeClick : nil
       ) {
-        HStack(spacing: 4) {
+        AdaptiveStack(hSpacing: 4, vSpacing: 2) {
           if !config.hideIcon {
             Image(systemName: config.icon)
               .font(.system(size: 10))

--- a/a-bar/Widgets/Custom/UserWidget.swift
+++ b/a-bar/Widgets/Custom/UserWidget.swift
@@ -62,7 +62,7 @@ struct UserWidget: View {
     if config.isActive && !(config.hideWhenEmpty && output.isEmpty && !isLoading) {
       BaseWidgetView(
         backgroundColor: customBackgroundColor,
-        onClick: config.clickCommand != nil ? executeClick : nil,
+        onClick: config.clickCommand != nil ? executeClick : nil
       ) {
         HStack(spacing: 4) {
           if !config.hideIcon {

--- a/a-bar/Widgets/Data/BatteryWidget.swift
+++ b/a-bar/Widgets/Data/BatteryWidget.swift
@@ -34,7 +34,7 @@ struct BatteryWidget: View {
       onClick: batterySettings.toggleCaffeinateOnClick ? toggleCaffeinate : nil
     ) {
       ZStack(alignment: .leading) {
-        HStack(spacing: 4) {
+        AdaptiveStack(hSpacing: 4, vSpacing: 2) {
           if batterySettings.showIcon {
             BatteryIconView(
               percentage: battery.percentage,

--- a/a-bar/Widgets/Data/DateWidget.swift
+++ b/a-bar/Widgets/Data/DateWidget.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Date display widget
 struct DateWidget: View {
   @EnvironmentObject var settings: SettingsManager
+  @Environment(\.widgetOrientation) var orientation
 
   @State private var currentDate = Date()
 
@@ -18,6 +19,10 @@ struct DateWidget: View {
     ThemeManager.currentTheme(for: settings.settings.theme)
   }
 
+  private var isVertical: Bool {
+    orientation == .vertical
+  }
+
   var body: some View {
     let bgColor = dateSettings.backgroundColor.color(from: theme)
     let fgColor =
@@ -29,7 +34,7 @@ struct DateWidget: View {
         ? theme.minor.opacity(0.95) : bgColor.opacity(0.95),
       onClick: openCalendar
     ) {
-      HStack(spacing: 4) {
+      AdaptiveStack(hSpacing: 4, vSpacing: 2) {
         if dateSettings.showIcon {
           Image(systemName: "calendar")
             .font(.system(size: 10))
@@ -49,7 +54,10 @@ struct DateWidget: View {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: dateSettings.locale)
 
-    if dateSettings.shortFormat {
+    if isVertical {
+      // Compact format for vertical bars: "Thu 6"
+      formatter.dateFormat = "EE d"
+    } else if dateSettings.shortFormat {
       formatter.dateFormat = "EE, MMM d"
     } else {
       formatter.dateFormat = "EEEE, MMM d"

--- a/a-bar/Widgets/Data/KeyboardWidget.swift
+++ b/a-bar/Widgets/Data/KeyboardWidget.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct KeyboardWidget: View {
   @EnvironmentObject var settings: SettingsManager
   @EnvironmentObject var systemInfo: SystemInfoService
+  @Environment(\.widgetOrientation) var orientation
 
   private var globalSettings: GlobalSettings {
     settings.settings.global
@@ -17,6 +18,10 @@ struct KeyboardWidget: View {
     ThemeManager.currentTheme(for: settings.settings.theme)
   }
 
+  private var isVertical: Bool {
+    orientation == .vertical
+  }
+
   var body: some View {
     let bgColor = keyboardSettings.backgroundColor.color(from: theme)
     let fgColor =
@@ -28,7 +33,7 @@ struct KeyboardWidget: View {
         ? theme.minor.opacity(0.95) : bgColor.opacity(0.95),
       onRightClick: openKeyboardPreferences
     ) {
-      HStack(spacing: 4) {
+      AdaptiveStack(hSpacing: 4, vSpacing: 2) {
         if keyboardSettings.showIcon {
           Image(systemName: "keyboard")
             .font(.system(size: 10))
@@ -42,8 +47,14 @@ struct KeyboardWidget: View {
   }
 
   private var formattedLayout: String {
-    // Show abbreviated version if too long
     let layout = systemInfo.keyboardLayout
+
+    if isVertical {
+      // Very short format for vertical: first 2-3 chars
+      return layout.prefix(3).uppercased()
+    }
+
+    // Show abbreviated version if too long
     if layout.count > 10 {
       // Try to get first word or abbreviation
       if let firstWord = layout.split(separator: " ").first {

--- a/a-bar/Widgets/Data/MicWidget.swift
+++ b/a-bar/Widgets/Data/MicWidget.swift
@@ -28,7 +28,7 @@ struct MicWidget: View {
         ? theme.minor.opacity(0.95) : bgColor.opacity(0.95),
       onRightClick: openSoundPreferences
     ) {
-      HStack(spacing: 4) {
+      AdaptiveStack(hSpacing: 4, vSpacing: 2) {
         if micSettings.showIcon {
           Image(systemName: micIcon)
             .font(.system(size: 11))

--- a/a-bar/Widgets/Data/SoundWidget.swift
+++ b/a-bar/Widgets/Data/SoundWidget.swift
@@ -57,7 +57,7 @@ struct SoundWidget: View {
       },
       onRightClick: openSoundPreferences
     ) {
-      HStack(spacing: 4) {
+      AdaptiveStack(hSpacing: 4, vSpacing: 2) {
         if soundSettings.showIcon {
           Image(systemName: volumeIcon)
             .font(.system(size: 11))

--- a/a-bar/Widgets/Data/TimeWidget.swift
+++ b/a-bar/Widgets/Data/TimeWidget.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Time widget
 struct TimeWidget: View {
   @EnvironmentObject var settings: SettingsManager
+  @Environment(\.widgetOrientation) var orientation
 
   @State private var currentTime = Date()
 
@@ -18,6 +19,10 @@ struct TimeWidget: View {
     ThemeManager.currentTheme(for: settings.settings.theme)
   }
 
+  private var isVertical: Bool {
+    orientation == .vertical
+  }
+
   var body: some View {
     let bgColor = timeSettings.backgroundColor.color(from: theme)
     let fgColor =
@@ -30,11 +35,11 @@ struct TimeWidget: View {
       noPadding: true
     ) {
       ZStack {
-        if timeSettings.showDayProgress {
+        if timeSettings.showDayProgress && !isVertical {
           DayProgressView(progress: currentTime.dayProgress, backgroundColor: fgColor)
             .ignoresSafeArea()
         }
-        HStack(spacing: 4) {
+        AdaptiveStack(hSpacing: 4, vSpacing: 2) {
           if timeSettings.showIcon {
             TimeIconView(time: currentTime, iconColor: fgColor)
           }
@@ -53,7 +58,10 @@ struct TimeWidget: View {
   private var formattedTime: String {
     let formatter = DateFormatter()
 
-    if timeSettings.hour12 {
+    if isVertical {
+      // Compact format for vertical bars: no seconds, no AM/PM
+      formatter.dateFormat = "HH:mm"
+    } else if timeSettings.hour12 {
       formatter.dateFormat = timeSettings.showSeconds ? "h:mm:ss a" : "h:mm a"
     } else {
       formatter.dateFormat = timeSettings.showSeconds ? "HH:mm:ss" : "HH:mm"

--- a/a-bar/Widgets/Data/WeatherWidget.swift
+++ b/a-bar/Widgets/Data/WeatherWidget.swift
@@ -3,22 +3,27 @@ import SwiftUI
 /// Weather widget showing current conditions
 struct WeatherWidget: View {
     @EnvironmentObject var settings: SettingsManager
-    
+    @Environment(\.widgetOrientation) var orientation
+
     @State private var weatherData: WeatherData?
     @State private var lastWeatherData: WeatherData?
     @State private var isLoading = true
     @State private var location: String = ""
-    
+
     private var weatherSettings: WeatherWidgetSettings {
         settings.settings.widgets.weather
     }
-    
+
     private var theme: ABarTheme {
         ThemeManager.currentTheme(for: settings.settings.theme)
     }
 
     private var globalSettings: GlobalSettings {
         settings.settings.global
+    }
+
+    private var isVertical: Bool {
+        orientation == .vertical
     }
 
     private func settingsFont(scaledBy factor: Double = 1.0, weight: Font.Weight? = nil, design: Font.Design? = nil) -> Font {
@@ -34,7 +39,7 @@ struct WeatherWidget: View {
         }
         return .custom(globalSettings.fontName, size: size)
     }
-    
+
     var body: some View {
         BaseWidgetView(onRightClick: refreshWeather) {
             if isLoading {
@@ -42,22 +47,23 @@ struct WeatherWidget: View {
                     .scaleEffect(0.5)
                     .frame(width: 16, height: 16)
             } else if let data = (weatherData ?? lastWeatherData) {
-                HStack(spacing: 4) {
+                AdaptiveStack(hSpacing: 4, vSpacing: 2) {
                     if weatherSettings.showIcon {
                         weatherIcon(for: data.description, atNight: data.isNight)
                     }
-                    
+
                     Text(temperatureString(weatherSettings.unit == .fahrenheit ? data.temperatureF : data.temperatureC))
                         .foregroundColor(theme.foreground)
-                    
-                    if !weatherSettings.hideLocation {
+
+                    // Hide location in vertical mode
+                    if !weatherSettings.hideLocation && !isVertical {
                             Text(location.truncated(to: 15))
                                 .font(settingsFont(scaledBy: 0.75))
                                 .foregroundColor(theme.minor)
                     }
                 }
             } else {
-                HStack(spacing: 4) {
+                AdaptiveStack(hSpacing: 4, vSpacing: 2) {
                     if weatherSettings.showIcon {
                         Image(systemName: "cloud.fill")
                             .font(.system(size: 10))

--- a/a-bar/Widgets/Data/WifiWidget.swift
+++ b/a-bar/Widgets/Data/WifiWidget.swift
@@ -40,6 +40,7 @@ func getCurrentSSID() -> String? {
 struct WifiWidget: View {
   @EnvironmentObject var settings: SettingsManager
   @EnvironmentObject var systemInfo: SystemInfoService
+  @Environment(\.widgetOrientation) var orientation
 
   private var wifiSettings: WifiWidgetSettings {
     settings.settings.widgets.wifi
@@ -55,6 +56,10 @@ struct WifiWidget: View {
 
   private var wifiInfo: WifiInfo {
     systemInfo.wifiInfo
+  }
+
+  private var isVertical: Bool {
+    orientation == .vertical
   }
 
   var body: some View {
@@ -73,14 +78,15 @@ struct WifiWidget: View {
         onClick: wifiSettings.toggleOnClick ? toggleWifi : nil,
         onRightClick: openWifiPreferences
       ) {
-        HStack(spacing: 4) {
+        AdaptiveStack(hSpacing: 4, vSpacing: 2) {
           if wifiSettings.showIcon {
             Image(systemName: wifiInfo.isActive ? "wifi" : "wifi.slash")
               .font(.system(size: 11))
               .foregroundColor(wifiInfo.isActive ? fgColor : theme.red)
           }
 
-          if !wifiSettings.hideNetworkName {
+          // In vertical mode, only show icon (hide network name)
+          if !wifiSettings.hideNetworkName && !isVertical {
             Text(displayName)
               .foregroundColor(wifiInfo.isActive ? fgColor : theme.minor)
           }

--- a/a-bar/Widgets/Graphs/CPUWidget.swift
+++ b/a-bar/Widgets/Graphs/CPUWidget.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CPUWidget: View {
   @EnvironmentObject var settings: SettingsManager
   @EnvironmentObject var systemInfo: SystemInfoService
+  @Environment(\.widgetOrientation) var orientation
 
   private var cpuSettings: CPUWidgetSettings {
     settings.settings.widgets.cpu
@@ -12,52 +13,84 @@ struct CPUWidget: View {
     ThemeManager.currentTheme(for: settings.settings.theme)
   }
 
+  private var isVertical: Bool {
+    orientation == .vertical
+  }
+
   var body: some View {
     let graphColor = cpuSettings.graphColor.color(from: theme)
-    
+
     BaseWidgetView(noPadding: true, onClick: openActivityMonitor) {
-      ZStack {
-        HStack {
-          GeometryReader { geometry in
-            GraphView(
-              values: systemInfo.cpuHistory.values,
-              maxValue: 100.0,
-              fillColor: graphColor,
-              lineColor: graphColor,
-              showLabels: false
-            )
-            .frame(
-              width: geometry.size.width,
-              height: geometry.size.height
-            )
-            .cornerRadius(4)
-            .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-          }
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-          .clipped()
-          .padding(.horizontal, 0)
-          .frame(width: 70)
-        }
-
-        // Icon overlay anchored to the left
-        HStack {
-          if cpuSettings.showIcon {
-            Image(systemName: "cpu")
-              .font(.system(size: 10))
-              .foregroundColor(graphColor)
-              .padding(.leading, 6)
-              .padding(.top, -6)
-          }
-          Spacer()
-        }
-
-        Text("\(Int(systemInfo.cpuUsage))%")
-          .foregroundColor(theme.foreground)
-          .frame(maxWidth: .infinity, alignment: .trailing)
-          .padding(.trailing, 6)
-          .padding(.top, -6)
+      if isVertical {
+        verticalContent(graphColor: graphColor)
+      } else {
+        horizontalContent(graphColor: graphColor)
       }
     }
+  }
+
+  @ViewBuilder
+  private func horizontalContent(graphColor: Color) -> some View {
+    ZStack {
+      HStack {
+        GeometryReader { geometry in
+          GraphView(
+            values: systemInfo.cpuHistory.values,
+            maxValue: 100.0,
+            fillColor: graphColor,
+            lineColor: graphColor,
+            showLabels: false,
+            vertical: false
+          )
+          .frame(
+            width: geometry.size.width,
+            height: geometry.size.height
+          )
+          .cornerRadius(4)
+          .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
+        .padding(.horizontal, 0)
+        .frame(width: 70)
+      }
+
+      // Icon overlay anchored to the left
+      HStack {
+        if cpuSettings.showIcon {
+          Image(systemName: "cpu")
+            .font(.system(size: 10))
+            .foregroundColor(graphColor)
+            .padding(.leading, 6)
+            .padding(.top, -6)
+        }
+        Spacer()
+      }
+
+      Text("\(Int(systemInfo.cpuUsage))%")
+        .foregroundColor(theme.foreground)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.trailing, 6)
+        .padding(.top, -6)
+    }
+  }
+
+  @ViewBuilder
+  private func verticalContent(graphColor: Color) -> some View {
+    VStack(spacing: 2) {
+      // Icon at top
+      if cpuSettings.showIcon {
+        Image(systemName: "cpu")
+          .font(.system(size: 10))
+          .foregroundColor(graphColor)
+      }
+
+      // Percentage
+      Text("\(Int(systemInfo.cpuUsage))%")
+        .font(.system(size: 9))
+        .foregroundColor(theme.foreground)
+    }
+    .padding(4)
   }
 
   private func openActivityMonitor() {

--- a/a-bar/Widgets/Graphs/DiskActivityWidget.swift
+++ b/a-bar/Widgets/Graphs/DiskActivityWidget.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct DiskActivityWidget: View {
   @EnvironmentObject var settings: SettingsManager
   @EnvironmentObject var systemInfo: SystemInfoService
+  @Environment(\.widgetOrientation) var orientation
 
   private var diskSettings: DiskActivityWidgetSettings {
     settings.settings.widgets.diskActivity
@@ -15,6 +16,10 @@ struct DiskActivityWidget: View {
 
   private var globalSettings: GlobalSettings {
     settings.settings.global
+  }
+
+  private var isVertical: Bool {
+    orientation == .vertical
   }
 
   private var userFont: Font {
@@ -42,68 +47,144 @@ struct DiskActivityWidget: View {
   var body: some View {
     let readColor = diskSettings.readColor.color(from: theme)
     let writeColor = diskSettings.writeColor.color(from: theme)
-    
+
     BaseWidgetView(noPadding: true, onClick: openActivityMonitor) {
-      ZStack {
-        // Center graph
-        GeometryReader { geometry in
-          ZStack {
-            // Read graph (blue)
-            GraphView(
-              values: systemInfo.diskReadHistory.values,
-              maxValue: max(1, systemInfo.diskReadHistory.values.max() ?? 1) * 1.2,
-              fillColor: readColor,
-              lineColor: readColor,
-              showLabels: false
-            )
-            // Write graph (red, overlayed)
-            GraphView(
-              values: systemInfo.diskWriteHistory.values,
-              maxValue: max(1, systemInfo.diskWriteHistory.values.max() ?? 1) * 1.2,
-              fillColor: writeColor,
-              lineColor: writeColor,
-              showLabels: false
-            )
-          }
-          .frame(width: geometry.size.width, height: geometry.size.height)
-          .cornerRadius(4)
-          .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .clipped()
-        .padding(.horizontal, 0)
-        .frame(width: 140)
-
-        // Read icon and speed (left)
-        HStack {
-          Image(systemName: "arrow.down.doc")
-            .font(.system(size: 10))
-            .foregroundColor(readColor)
-            .padding(.leading, 6)
-            .padding(.top, -6)
-          Text(formatSpeed(Double(systemInfo.diskStats.read)))
-            .font(settingsFont(scaledBy: 0.8))
-            .foregroundColor(theme.foreground)
-            .padding(.top, -6)
-            .padding(.leading, -4)
-          Spacer()
-        }
-
-        // Write icon and speed (right)
-        HStack {
-          Spacer()
-          Text(formatSpeed(Double(systemInfo.diskStats.write)))
-            .font(settingsFont(scaledBy: 0.8))
-            .foregroundColor(theme.foreground)
-            .padding(.top, -6)
-            .padding(.trailing, -4)
-          Image(systemName: "arrow.up.doc")
-            .font(.system(size: 10))
-            .foregroundColor(writeColor)
-            .padding(.trailing, 6)
-            .padding(.top, -6)
-        }
+      if isVertical {
+        verticalContent(readColor: readColor, writeColor: writeColor)
+      } else {
+        horizontalContent(readColor: readColor, writeColor: writeColor)
       }
+    }
+  }
+
+  @ViewBuilder
+  private func horizontalContent(readColor: Color, writeColor: Color) -> some View {
+    ZStack {
+      // Center graph
+      GeometryReader { geometry in
+        ZStack {
+          // Read graph (blue)
+          GraphView(
+            values: systemInfo.diskReadHistory.values,
+            maxValue: max(1, systemInfo.diskReadHistory.values.max() ?? 1) * 1.2,
+            fillColor: readColor,
+            lineColor: readColor,
+            showLabels: false,
+            vertical: false
+          )
+          // Write graph (red, overlayed)
+          GraphView(
+            values: systemInfo.diskWriteHistory.values,
+            maxValue: max(1, systemInfo.diskWriteHistory.values.max() ?? 1) * 1.2,
+            fillColor: writeColor,
+            lineColor: writeColor,
+            showLabels: false,
+            vertical: false
+          )
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height)
+        .cornerRadius(4)
+        .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .clipped()
+      .padding(.horizontal, 0)
+      .frame(width: 140)
+
+      // Read icon and speed (left)
+      HStack {
+        Image(systemName: "arrow.down.doc")
+          .font(.system(size: 10))
+          .foregroundColor(readColor)
+          .padding(.leading, 6)
+          .padding(.top, -6)
+        Text(formatSpeed(Double(systemInfo.diskStats.read)))
+          .font(settingsFont(scaledBy: 0.8))
+          .foregroundColor(theme.foreground)
+          .padding(.top, -6)
+          .padding(.leading, -4)
+        Spacer()
+      }
+
+      // Write icon and speed (right)
+      HStack {
+        Spacer()
+        Text(formatSpeed(Double(systemInfo.diskStats.write)))
+          .font(settingsFont(scaledBy: 0.8))
+          .foregroundColor(theme.foreground)
+          .padding(.top, -6)
+          .padding(.trailing, -4)
+        Image(systemName: "arrow.up.doc")
+          .font(.system(size: 10))
+          .foregroundColor(writeColor)
+          .padding(.trailing, 6)
+          .padding(.top, -6)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func verticalContent(readColor: Color, writeColor: Color) -> some View {
+    VStack(spacing: 2) {
+      // Read stats
+      HStack(spacing: 2) {
+        Image(systemName: "arrow.down.doc")
+          .font(.system(size: 8))
+          .foregroundColor(readColor)
+        Text(formatSpeedCompact(Double(systemInfo.diskStats.read)))
+          .font(.system(size: 8))
+          .foregroundColor(theme.foreground)
+      }
+
+      // Write stats
+      HStack(spacing: 2) {
+        Image(systemName: "arrow.up.doc")
+          .font(.system(size: 8))
+          .foregroundColor(writeColor)
+        Text(formatSpeedCompact(Double(systemInfo.diskStats.write)))
+          .font(.system(size: 8))
+          .foregroundColor(theme.foreground)
+      }
+
+      // Vertical graph
+      GeometryReader { geometry in
+        ZStack {
+          GraphView(
+            values: systemInfo.diskReadHistory.values,
+            maxValue: max(1, systemInfo.diskReadHistory.values.max() ?? 1) * 1.2,
+            fillColor: readColor,
+            lineColor: readColor,
+            showLabels: false,
+            vertical: true
+          )
+          GraphView(
+            values: systemInfo.diskWriteHistory.values,
+            maxValue: max(1, systemInfo.diskWriteHistory.values.max() ?? 1) * 1.2,
+            fillColor: writeColor,
+            lineColor: writeColor,
+            showLabels: false,
+            vertical: true
+          )
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height)
+        .cornerRadius(4)
+      }
+      .frame(maxWidth: .infinity)
+      .frame(height: 50)
+      .clipped()
+    }
+    .padding(4)
+  }
+
+  private func formatSpeedCompact(_ bytesPerSecond: Double) -> String {
+    if bytesPerSecond < 1024 {
+      return String(format: "%.0fB", bytesPerSecond)
+    } else if bytesPerSecond < 1024 * 1024 {
+      return String(format: "%.0fK", bytesPerSecond / 1024)
+    } else if bytesPerSecond < 1024 * 1024 * 1024 {
+      return String(format: "%.1fM", bytesPerSecond / 1024 / 1024)
+    } else {
+      return String(format: "%.1fG", bytesPerSecond / 1024 / 1024 / 1024)
     }
   }
 

--- a/a-bar/Widgets/Graphs/GPUWidget.swift
+++ b/a-bar/Widgets/Graphs/GPUWidget.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct GPUWidget: View {
   @EnvironmentObject var settings: SettingsManager
   @EnvironmentObject var systemInfo: SystemInfoService
+  @Environment(\.widgetOrientation) var orientation
 
   private var gpuSettings: GPUWidgetSettings {
     settings.settings.widgets.gpu
@@ -12,59 +13,109 @@ struct GPUWidget: View {
     ThemeManager.currentTheme(for: settings.settings.theme)
   }
 
+  private var isVertical: Bool {
+    orientation == .vertical
+  }
+
   var body: some View {
     let isLoading = systemInfo.gpuUsage == 0 && systemInfo.gpuHistory.values.isEmpty
     let graphColor = gpuSettings.graphColor.color(from: theme)
-    
+
     BaseWidgetView(noPadding: !isLoading, onClick: openActivityMonitor) {
       if isLoading {
         ProgressView()
           .scaleEffect(0.5)
           .frame(width: 16, height: 16)
+      } else if isVertical {
+        verticalContent(graphColor: graphColor)
       } else {
-        ZStack {
-          HStack {
-            GeometryReader { geometry in
-              GraphView(
-                values: systemInfo.gpuHistory.values,
-                maxValue: 100.0,
-                fillColor: graphColor,
-                lineColor: graphColor,
-                showLabels: false
-              )
-              .frame(
-                width: geometry.size.width,
-                height: geometry.size.height
-              )
-              .cornerRadius(4)
-              .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .clipped()
-            .padding(.horizontal, 0)
-            .frame(width: 70)
-          }
-
-          // Icon overlay anchored to the left
-          HStack {
-            if gpuSettings.showIcon {
-              Image(systemName: "cpu")
-                .font(.system(size: 10))
-                .foregroundColor(graphColor)
-                .padding(.leading, 6)
-                .padding(.top, -6)
-            }
-            Spacer()
-          }
-
-          Text("\(Int(systemInfo.gpuUsage))%")
-            .foregroundColor(theme.foreground)
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .padding(.trailing, 6)
-            .padding(.top, -6)
-        }
+        horizontalContent(graphColor: graphColor)
       }
     }
+  }
+
+  @ViewBuilder
+  private func horizontalContent(graphColor: Color) -> some View {
+    ZStack {
+      HStack {
+        GeometryReader { geometry in
+          GraphView(
+            values: systemInfo.gpuHistory.values,
+            maxValue: 100.0,
+            fillColor: graphColor,
+            lineColor: graphColor,
+            showLabels: false,
+            vertical: false
+          )
+          .frame(
+            width: geometry.size.width,
+            height: geometry.size.height
+          )
+          .cornerRadius(4)
+          .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
+        .padding(.horizontal, 0)
+        .frame(width: 70)
+      }
+
+      // Icon overlay anchored to the left
+      HStack {
+        if gpuSettings.showIcon {
+          Image(systemName: "cpu")
+            .font(.system(size: 10))
+            .foregroundColor(graphColor)
+            .padding(.leading, 6)
+            .padding(.top, -6)
+        }
+        Spacer()
+      }
+
+      Text("\(Int(systemInfo.gpuUsage))%")
+        .foregroundColor(theme.foreground)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.trailing, 6)
+        .padding(.top, -6)
+    }
+  }
+
+  @ViewBuilder
+  private func verticalContent(graphColor: Color) -> some View {
+    VStack(spacing: 2) {
+      // Icon at top
+      if gpuSettings.showIcon {
+        Image(systemName: "cpu")
+          .font(.system(size: 10))
+          .foregroundColor(graphColor)
+      }
+
+      // Percentage
+      Text("\(Int(systemInfo.gpuUsage))%")
+        .font(.system(size: 9))
+        .foregroundColor(theme.foreground)
+
+      // Vertical graph
+      GeometryReader { geometry in
+        GraphView(
+          values: systemInfo.gpuHistory.values,
+          maxValue: 100.0,
+          fillColor: graphColor,
+          lineColor: graphColor,
+          showLabels: false,
+          vertical: true
+        )
+        .frame(
+          width: geometry.size.width,
+          height: geometry.size.height
+        )
+        .cornerRadius(4)
+      }
+      .frame(maxWidth: .infinity)
+      .frame(height: 60)
+      .clipped()
+    }
+    .padding(4)
   }
 
   private func openActivityMonitor() {

--- a/a-bar/Widgets/Graphs/MemoryWidget.swift
+++ b/a-bar/Widgets/Graphs/MemoryWidget.swift
@@ -25,7 +25,7 @@ struct MemoryWidget: View {
 
   var body: some View {
     BaseWidgetView(onClick: openActivityMonitor) {
-      HStack(spacing: 4) {
+      AdaptiveStack(hSpacing: 4, vSpacing: 2) {
         PieChartView(
           usedPercentage: systemInfo.memoryPressure,
           usedColor: memoryColor,

--- a/a-bar/Widgets/Graphs/NetstatsWidget.swift
+++ b/a-bar/Widgets/Graphs/NetstatsWidget.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct NetstatsWidget: View {
   @EnvironmentObject var settings: SettingsManager
   @EnvironmentObject var systemInfo: SystemInfoService
+  @Environment(\.widgetOrientation) var orientation
 
   private var netstatsSettings: NetstatsWidgetSettings {
     settings.settings.widgets.netstats
@@ -15,6 +16,10 @@ struct NetstatsWidget: View {
 
   private var globalSettings: GlobalSettings {
     settings.settings.global
+  }
+
+  private var isVertical: Bool {
+    orientation == .vertical
   }
 
   private var userFont: Font {
@@ -42,68 +47,144 @@ struct NetstatsWidget: View {
   var body: some View {
     let downloadColor = netstatsSettings.downloadColor.color(from: theme)
     let uploadColor = netstatsSettings.uploadColor.color(from: theme)
-    
+
     BaseWidgetView(noPadding: true, onClick: openNetworkUtility) {
-      ZStack {
-        // Center graph
-        GeometryReader { geometry in
-          ZStack {
-            // Download graph (magenta)
-            GraphView(
-              values: systemInfo.downloadHistory.values,
-              maxValue: max(1, systemInfo.downloadHistory.values.max() ?? 1) * 1.2,
-              fillColor: downloadColor,
-              lineColor: downloadColor,
-              showLabels: false
-            )
-            // Upload graph (blue, overlayed)
-            GraphView(
-              values: systemInfo.uploadHistory.values,
-              maxValue: max(1, systemInfo.uploadHistory.values.max() ?? 1) * 1.2,
-              fillColor: uploadColor,
-              lineColor: uploadColor,
-              showLabels: false
-            )
-          }
-          .frame(width: geometry.size.width, height: geometry.size.height)
-          .cornerRadius(4)
-          .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .clipped()
-        .padding(.horizontal, 0)
-        .frame(width: 140)
-
-        // Download icon and speed (left)
-        HStack {
-          Image(systemName: "arrow.down")
-            .font(.system(size: 10))
-            .foregroundColor(downloadColor)
-            .padding(.leading, 6)
-            .padding(.top, -6)
-          Text(formatSpeed(Double(systemInfo.networkStats.download)))
-            .font(settingsFont(scaledBy: 0.8))
-            .foregroundColor(theme.foreground)
-            .padding(.top, -6)
-            .padding(.leading, -4)
-          Spacer()
-        }
-
-        // Upload icon and speed (right)
-        HStack {
-          Spacer()
-          Text(formatSpeed(Double(systemInfo.networkStats.upload)))
-            .font(settingsFont(scaledBy: 0.8))
-            .foregroundColor(theme.foreground)
-            .padding(.top, -6)
-            .padding(.trailing, -4)
-          Image(systemName: "arrow.up")
-            .font(.system(size: 10))
-            .foregroundColor(uploadColor)
-            .padding(.trailing, 6)
-            .padding(.top, -6)
-        }
+      if isVertical {
+        verticalContent(downloadColor: downloadColor, uploadColor: uploadColor)
+      } else {
+        horizontalContent(downloadColor: downloadColor, uploadColor: uploadColor)
       }
+    }
+  }
+
+  @ViewBuilder
+  private func horizontalContent(downloadColor: Color, uploadColor: Color) -> some View {
+    ZStack {
+      // Center graph
+      GeometryReader { geometry in
+        ZStack {
+          // Download graph (magenta)
+          GraphView(
+            values: systemInfo.downloadHistory.values,
+            maxValue: max(1, systemInfo.downloadHistory.values.max() ?? 1) * 1.2,
+            fillColor: downloadColor,
+            lineColor: downloadColor,
+            showLabels: false,
+            vertical: false
+          )
+          // Upload graph (blue, overlayed)
+          GraphView(
+            values: systemInfo.uploadHistory.values,
+            maxValue: max(1, systemInfo.uploadHistory.values.max() ?? 1) * 1.2,
+            fillColor: uploadColor,
+            lineColor: uploadColor,
+            showLabels: false,
+            vertical: false
+          )
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height)
+        .cornerRadius(4)
+        .position(x: geometry.size.width / 2, y: geometry.size.height / 2)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .clipped()
+      .padding(.horizontal, 0)
+      .frame(width: 140)
+
+      // Download icon and speed (left)
+      HStack {
+        Image(systemName: "arrow.down")
+          .font(.system(size: 10))
+          .foregroundColor(downloadColor)
+          .padding(.leading, 6)
+          .padding(.top, -6)
+        Text(formatSpeed(Double(systemInfo.networkStats.download)))
+          .font(settingsFont(scaledBy: 0.8))
+          .foregroundColor(theme.foreground)
+          .padding(.top, -6)
+          .padding(.leading, -4)
+        Spacer()
+      }
+
+      // Upload icon and speed (right)
+      HStack {
+        Spacer()
+        Text(formatSpeed(Double(systemInfo.networkStats.upload)))
+          .font(settingsFont(scaledBy: 0.8))
+          .foregroundColor(theme.foreground)
+          .padding(.top, -6)
+          .padding(.trailing, -4)
+        Image(systemName: "arrow.up")
+          .font(.system(size: 10))
+          .foregroundColor(uploadColor)
+          .padding(.trailing, 6)
+          .padding(.top, -6)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func verticalContent(downloadColor: Color, uploadColor: Color) -> some View {
+    VStack(spacing: 2) {
+      // Download stats
+      HStack(spacing: 2) {
+        Image(systemName: "arrow.down")
+          .font(.system(size: 8))
+          .foregroundColor(downloadColor)
+        Text(formatSpeedCompact(Double(systemInfo.networkStats.download)))
+          .font(.system(size: 8))
+          .foregroundColor(theme.foreground)
+      }
+
+      // Upload stats
+      HStack(spacing: 2) {
+        Image(systemName: "arrow.up")
+          .font(.system(size: 8))
+          .foregroundColor(uploadColor)
+        Text(formatSpeedCompact(Double(systemInfo.networkStats.upload)))
+          .font(.system(size: 8))
+          .foregroundColor(theme.foreground)
+      }
+
+      // Vertical graph
+      GeometryReader { geometry in
+        ZStack {
+          GraphView(
+            values: systemInfo.downloadHistory.values,
+            maxValue: max(1, systemInfo.downloadHistory.values.max() ?? 1) * 1.2,
+            fillColor: downloadColor,
+            lineColor: downloadColor,
+            showLabels: false,
+            vertical: true
+          )
+          GraphView(
+            values: systemInfo.uploadHistory.values,
+            maxValue: max(1, systemInfo.uploadHistory.values.max() ?? 1) * 1.2,
+            fillColor: uploadColor,
+            lineColor: uploadColor,
+            showLabels: false,
+            vertical: true
+          )
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height)
+        .cornerRadius(4)
+      }
+      .frame(maxWidth: .infinity)
+      .frame(height: 50)
+      .clipped()
+    }
+    .padding(4)
+  }
+
+  private func formatSpeedCompact(_ bytesPerSecond: Double) -> String {
+    if bytesPerSecond < 1024 {
+      return String(format: "%.0fB", bytesPerSecond)
+    } else if bytesPerSecond < 1024 * 1024 {
+      return String(format: "%.0fK", bytesPerSecond / 1024)
+    } else if bytesPerSecond < 1024 * 1024 * 1024 {
+      return String(format: "%.1fM", bytesPerSecond / 1024 / 1024)
+    } else {
+      return String(format: "%.1fG", bytesPerSecond / 1024 / 1024 / 1024)
     }
   }
 

--- a/a-bar/Widgets/Yabai/OpenedAppsView.swift
+++ b/a-bar/Widgets/Yabai/OpenedAppsView.swift
@@ -4,23 +4,37 @@ import SwiftUI
 struct OpenedAppsView: View {
     let space: YabaiSpace
     let displayIndex: Int
-    
+
     @EnvironmentObject var settings: SettingsManager
     @EnvironmentObject var yabaiService: YabaiService
-    
+    @Environment(\.widgetOrientation) var orientation
+
     private var spacesSettings: SpacesWidgetSettings {
         settings.settings.widgets.spaces
     }
-    
+
     private var theme: ABarTheme {
         ThemeManager.currentTheme(for: settings.settings.theme)
     }
-    
+
+    private var isVertical: Bool {
+        orientation == .vertical
+    }
+
     var body: some View {
         if !displayedApps.isEmpty {
-            HStack(spacing: 1) {
-                ForEach(displayedApps, id: \.id) { window in
-                    AppIconButton(window: window)
+            if isVertical {
+                // In vertical mode, show fewer icons or wrap them
+                VStack(spacing: 1) {
+                    ForEach(displayedApps.prefix(3), id: \.id) { window in
+                        AppIconButton(window: window)
+                    }
+                }
+            } else {
+                HStack(spacing: 1) {
+                    ForEach(displayedApps, id: \.id) { window in
+                        AppIconButton(window: window)
+                    }
                 }
             }
         }

--- a/a-bar/Widgets/Yabai/ProcessWidget.swift
+++ b/a-bar/Widgets/Yabai/ProcessWidget.swift
@@ -3,18 +3,23 @@ import SwiftUI
 /// Widget showing the currently focused application and window
 struct ProcessWidget: View {
     let displayIndex: Int
-    
+
     @EnvironmentObject var settings: SettingsManager
     @EnvironmentObject var yabaiService: YabaiService
-    
+    @Environment(\.widgetOrientation) var orientation
+
     private var processSettings: ProcessWidgetSettings {
         settings.settings.widgets.process
     }
-    
+
     private var theme: ABarTheme {
         ThemeManager.currentTheme(for: settings.settings.theme)
     }
-    
+
+    private var isVertical: Bool {
+        orientation == .vertical
+    }
+
     var body: some View {
         let globalSettings = settings.settings.global
         let userFont: Font = globalSettings.fontName.isEmpty ? .system(size: CGFloat(globalSettings.fontSize)) : .custom(globalSettings.fontName, size: CGFloat(globalSettings.fontSize))
@@ -54,109 +59,203 @@ struct ProcessWidget: View {
 
         if orderedWindows.isEmpty {
             // No windows: show desktop
-            HStack(spacing: 4) {
+            AdaptiveStack(hSpacing: 4, vSpacing: 2) {
                 Image(systemName: "app.dashed")
                     .font(userFont)
                     .foregroundColor(theme.foreground.opacity(0.6))
-                if !processSettings.displayOnlyIcon {
+                if !processSettings.displayOnlyIcon && !isVertical {
                     Text("Desktop")
                         .font(userFont)
                         .foregroundColor(theme.foreground.opacity(0.6))
                 }
             }
             .padding(.horizontal, 6)
-            .padding(.leading, 4)
+            .padding(.leading, isVertical ? 0 : 4)
             .padding(.vertical, 3)
         } else {
+            if isVertical {
+                verticalWindowsContent(
+                    orderedWindows: orderedWindows,
+                    focusedWin: focusedWin,
+                    layoutMode: layoutMode,
+                    globalSettings: globalSettings,
+                    userFont: userFont,
+                    userFontSmall: userFontSmall
+                )
+            } else {
+                horizontalWindowsContent(
+                    orderedWindows: orderedWindows,
+                    focusedWin: focusedWin,
+                    layoutMode: layoutMode,
+                    globalSettings: globalSettings,
+                    userFont: userFont,
+                    userFontSmall: userFontSmall
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func horizontalWindowsContent(
+        orderedWindows: [YabaiWindow],
+        focusedWin: YabaiWindow?,
+        layoutMode: String?,
+        globalSettings: GlobalSettings,
+        userFont: Font,
+        userFontSmall: Font
+    ) -> some View {
+        HStack(spacing: globalSettings.barElementGap) {
+            if let layoutMode = layoutMode, processSettings.showLayoutMode {
+                Text(layoutMode)
+                    .font(userFont.weight(.medium))
+                    .foregroundColor(theme.foreground.opacity(0.9))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(theme.mainAlt.opacity(0.5))
+                    )
+            }
+            ForEach(orderedWindows, id: \.id) { window in
+                windowView(
+                    window: window,
+                    isFocused: window.id == focusedWin?.id,
+                    globalSettings: globalSettings,
+                    userFont: userFont,
+                    userFontSmall: userFontSmall
+                )
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+    }
+
+    @ViewBuilder
+    private func verticalWindowsContent(
+        orderedWindows: [YabaiWindow],
+        focusedWin: YabaiWindow?,
+        layoutMode: String?,
+        globalSettings: GlobalSettings,
+        userFont: Font,
+        userFontSmall: Font
+    ) -> some View {
+        VStack(spacing: globalSettings.barElementGap) {
+            if let layoutMode = layoutMode, processSettings.showLayoutMode {
+                Text(layoutMode)
+                    .font(userFont.weight(.medium))
+                    .foregroundColor(theme.foreground.opacity(0.9))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(theme.mainAlt.opacity(0.5))
+                    )
+            }
+            ForEach(orderedWindows, id: \.id) { window in
+                // In vertical mode, only show app icon
+                AppIconView(appName: window.app, size: 16)
+                    .opacity(window.id == focusedWin?.id ? 1.0 : 0.6)
+                    .padding(4)
+                    .background(
+                        window.id == focusedWin?.id
+                            ? RoundedRectangle(cornerRadius: 4).fill(theme.mainAlt.opacity(0.5))
+                            : nil
+                    )
+                    .onTapGesture {
+                        focusWindow(window)
+                    }
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.pointingHand.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 3)
+    }
+
+    @ViewBuilder
+    private func windowView(
+        window: YabaiWindow,
+        isFocused: Bool,
+        globalSettings: GlobalSettings,
+        userFont: Font,
+        userFontSmall: Font
+    ) -> some View {
+        if isFocused {
+            // Focused window: show icon, app name, title, and optional stack index badge on the right
             HStack(spacing: globalSettings.barElementGap) {
-                if let layoutMode = layoutMode, processSettings.showLayoutMode {
-                    Text(layoutMode)
-                        .font(userFont.weight(.medium))
-                        .foregroundColor(theme.foreground.opacity(0.9))
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 3)
-                        .background(
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(theme.mainAlt.opacity(0.5))
-                        )
-                }
-                ForEach(orderedWindows, id: \.id) { window in
-                    if window.id == focusedWin?.id {
-                        // Focused window: show icon, app name, title, and optional stack index badge on the right
-                        HStack(spacing: globalSettings.barElementGap) {
-                            AppIconView(appName: window.app, size: 16)
-                            if !processSettings.displayOnlyIcon {
-                                VStack(alignment: .leading, spacing: -1) {
-                                    Text(window.app)
-                                        .font(userFont.weight(.medium))
-                                        .foregroundColor(theme.foreground)
-                                    if !processSettings.hideWindowTitle && !window.title.isEmpty {
-                                        Text(window.title.truncated(to: 20))
-                                            .font(userFont)
-                                            .foregroundColor(theme.foreground.opacity(0.7))
-                                    }
-                                }
-                            }
-                            if let idx = window.stackIndex, idx != 0 {
-                                Text("\(idx)")
-                                    .font(userFontSmall.weight(.medium))
-                                    .foregroundColor(theme.foreground.opacity(0.9))
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .fill(theme.minor.opacity(0.5))
-                                    )
-                            }
-                        }
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, processSettings.hideWindowTitle || processSettings.displayOnlyIcon ? 3 : 0)
-                        .background(
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(theme.mainAlt.opacity(0.5))
-                        )
-                        .onTapGesture {
-                            focusWindow(window)
-                        }
-                        .onHover { hovering in
-                            if hovering {
-                                NSCursor.pointingHand.push()
-                            } else {
-                                NSCursor.pop()
-                            }
-                        }
-                    } else {
-                        // Non-focused window: show only icon, optionally with small stack index badge
-                        HStack(spacing: 4) {
-                            AppIconView(appName: window.app, size: 16)
-                            if let idx = window.stackIndex, idx != 0 {
-                                Text("\(idx)")
-                                    .font(userFontSmall.weight(.medium))
-                                    .foregroundColor(theme.foreground.opacity(0.85))
-                                    .padding(.horizontal, 4)
-                                    .padding(.vertical, 1)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 3)
-                                            .fill(theme.minor.opacity(0.5))
-                                    )
-                            }
-                        }
-                        .opacity(0.8)
-                        .onTapGesture {
-                            focusWindow(window)
-                        }
-                        .onHover { hovering in
-                            if hovering {
-                                NSCursor.pointingHand.push()
-                            } else {
-                                NSCursor.pop()
-                            }
+                AppIconView(appName: window.app, size: 16)
+                if !processSettings.displayOnlyIcon {
+                    VStack(alignment: .leading, spacing: -1) {
+                        Text(window.app)
+                            .font(userFont.weight(.medium))
+                            .foregroundColor(theme.foreground)
+                        if !processSettings.hideWindowTitle && !window.title.isEmpty {
+                            Text(window.title.truncated(to: 20))
+                                .font(userFont)
+                                .foregroundColor(theme.foreground.opacity(0.7))
                         }
                     }
                 }
+                if let idx = window.stackIndex, idx != 0 {
+                    Text("\(idx)")
+                        .font(userFontSmall.weight(.medium))
+                        .foregroundColor(theme.foreground.opacity(0.9))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(theme.minor.opacity(0.5))
+                        )
+                }
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
+            .padding(.horizontal, 4)
+            .padding(.vertical, processSettings.hideWindowTitle || processSettings.displayOnlyIcon ? 3 : 0)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(theme.mainAlt.opacity(0.5))
+            )
+            .onTapGesture {
+                focusWindow(window)
+            }
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+        } else {
+            // Non-focused window: show only icon, optionally with small stack index badge
+            HStack(spacing: 4) {
+                AppIconView(appName: window.app, size: 16)
+                if let idx = window.stackIndex, idx != 0 {
+                    Text("\(idx)")
+                        .font(userFontSmall.weight(.medium))
+                        .foregroundColor(theme.foreground.opacity(0.85))
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(theme.minor.opacity(0.5))
+                        )
+                }
+            }
+            .opacity(0.8)
+            .onTapGesture {
+                focusWindow(window)
+            }
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- Add left and right bar positions alongside existing top/bottom bars
- Implement vertical layouts for all widgets with compact text formats
- Add orientation-aware graph drawing (bottom-to-top for vertical bars)

## Changes
- Core: Add `left`/`right` cases to `BarPosition` enum with `isVertical` property
- Window: Calculate frames for vertical bars using configurable `barWidth` setting
- Layout: Add `AdaptiveStack` helper and `WidgetOrientation` environment value
- Widgets: All widgets adapt layouts based on orientation (VStack for vertical)
- Settings: Add left/right bar toggles and bar width slider (40-300px)

## Test plan
- [ ] Enable left or right bar from Settings > Layout
- [ ] Add various widgets and verify they display vertically
- [ ] Adjust bar width in Appearance settings
- [ ] Test with multiple displays